### PR TITLE
configurable my_cnf option for Test::mysqld::Pool

### DIFF
--- a/lib/App/Prove/Plugin/MySQLPool.pm
+++ b/lib/App/Prove/Plugin/MySQLPool.pm
@@ -139,6 +139,19 @@ you'd better erase all rows inserted at the top of your tests.
 
     $dbh->do( "TRUNCATE $_" ) for @tables;
 
+If you need customize my.cnf, you may want to implement C<my_cnf> method in MyApp::Test::DB.
+
+    # MyApp::Test::DB
+    sub my_cnf {
+        +{
+            "skip-networking" => "",
+            "character-set-server" => "utf8mb4",
+        };
+    }
+
+This config is used before launching Test::mysqld instances.
+So you can set non-dynamic system variables.
+
 =head1 AUTHOR
 
 Masakazu Ohtsuka E<lt>o.masakazu@gmail.comE<gt>


### PR DESCRIPTION
``` perl
package MyProject::DB::Preparer;

sub prepare { ... }

sub my_cnf {
    +{
        "skip-networking" => "",
        "character-set-server" => "utf8mb4",
    };
}
```

```
$ prove -PMySQLPool=MyProject::DB::Preparer ...
```

のような感じでmy_cnfを渡せるようにしました。よろしくお願いします。
