### PR TITLE
load preparer to call my_cnf method

### DIFF
--- a/lib/App/Prove/Plugin/MySQLPool.pm
+++ b/lib/App/Prove/Plugin/MySQLPool.pm
@@ -18,20 +18,18 @@ sub load {
     my $pool       = Test::mysqld::Pool->new(
         jobs       => $jobs,
         share_file => $share_file->filename,
-        ($preparer ? (
-            preparer => sub {
-                my ($mysqld) = @_;
-
-                push( @INC, 'lib' )
-                    if $lib;
-
-                eval "require $preparer" ## no critic
-                    or die "$@";
-
-                $preparer->prepare( $mysqld );
-            },
-            $preparer->can('my_cnf') ? ( my_cnf => $preparer->my_cnf ) : (),
-        ) : ()),
+        ($preparer ? do {
+            push( @INC, 'lib' ) if $lib;
+            eval "require $preparer" ## no critic
+                or die "$@";
+            (
+                preparer => sub {
+                    my ($mysqld) = @_;
+                    $preparer->prepare( $mysqld );
+                },
+                $preparer->can('my_cnf') ? ( my_cnf => $preparer->my_cnf ) : (),
+            )
+        } : ()),
     );
     $pool->prepare;
 


### PR DESCRIPTION
- `$preparer->can('my_cnf')` always returns `undef` because `$preparer` is not loaded.
- load $preparer to call `my_cnf` method.