### PR TITLE
restrict execution the forking hook only for the direct children

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,7 +88,7 @@ jobs:
         with:
           path: |
             local
-          key: ${{ runner.os }}-${{ matrix.perl }}-${{ hashFiles('**/cpanfile') }}
+          key: ${{ runner.os }}-${{ matrix.perl }}-${{ matrix.mysql }}-${{ hashFiles('**/cpanfile') }}
 
       - name: install dependencies
         run: |

--- a/lib/App/Prove/Plugin/MySQLPool.pm
+++ b/lib/App/Prove/Plugin/MySQLPool.pm
@@ -45,29 +45,36 @@ sub load {
 
     $ENV{ PERL_APP_PROVE_PLUGIN_MYSQLPOOL_SHARE_FILE } = $share_file->filename;
 
-    POSIX::AtFork->add_to_child( \&child_hook );
+    POSIX::AtFork->add_to_child(create_child_hook($$));
 
     1;
 }
 
-sub child_hook {
-    my ($call) = @_;
+sub create_child_hook {
+    my ($ppid) = @_;
+    return sub {
+        my ($call) = @_;
 
-    # we're in the test process
+        # we're in the test process
 
-    # prove uses 'fork' to create child processes
-    # our own 'ps -o pid ...' uses 'backtick'
-    # only hook 'fork'
-    ($call eq 'fork')
-        or return;
+        # prove uses 'fork' to create child processes
+        # our own 'ps -o pid ...' uses 'backtick'
+        # only hook 'fork'
+        ($call eq 'fork')
+            or return;
 
-    my $share_file = $ENV{ PERL_APP_PROVE_PLUGIN_MYSQLPOOL_SHARE_FILE }
-        or return;
+        # restrict only direct child of prove
+        (getppid() == $ppid)
+            or return;
 
-    my $dsn = Test::mysqld::Pool->new( share_file => $share_file )->alloc;
+        my $share_file = $ENV{ PERL_APP_PROVE_PLUGIN_MYSQLPOOL_SHARE_FILE }
+            or return;
 
-    # use this in tests
-    $ENV{ PERL_TEST_MYSQLPOOL_DSN } = $dsn;
+        my $dsn = Test::mysqld::Pool->new( share_file => $share_file )->alloc;
+
+        # use this in tests
+        $ENV{ PERL_TEST_MYSQLPOOL_DSN } = $dsn;
+    };
 }
 
 {

--- a/t/01_env_dsn.t
+++ b/t/01_env_dsn.t
@@ -11,11 +11,14 @@ use t::Util;
 my $out = run_test({
     tests => [ 't/plx/1.plx', 't/plx/2.plx' ],
 });
-exit_status_is( 0 );
+exit_status_is( 0 )
+    or diag "out = '$out'";
 
 my (@dsns) = ( $out =~ m!dsn:(.+)$!gm );
 
-is( (scalar @dsns), 2 );
-isnt( $dsns[ 0 ], $dsns[ 1 ] );
+is( (scalar @dsns), 2 )
+    or diag explain { dsns => \@dsns, out => $out };
+isnt( $dsns[ 0 ], $dsns[ 1 ] )
+    or diag explain { dsns => \@dsns, out => $out };
 
 done_testing;

--- a/t/01_env_dsn.t
+++ b/t/01_env_dsn.t
@@ -1,6 +1,6 @@
 use Test::More;
-plan skip_all => 'mysql_install_db not found'
-    unless `which mysql_install_db 2>/dev/null`;
+plan skip_all => 'mysql_install_db or mysqld --intiialize-insecure are not found'
+    unless `which mysql_install_db 2>/dev/null` || `mysqld --verbose --help 2>/dev/null | grep '\\--initialize-insecure'`;
 use strict;
 use warnings;
 

--- a/t/02_prepare.t
+++ b/t/02_prepare.t
@@ -1,6 +1,6 @@
 use Test::More;
-plan skip_all => 'mysql_install_db not found'
-    unless `which mysql_install_db 2>/dev/null`;
+plan skip_all => 'mysql_install_db or mysqld --intiialize-insecure are not found'
+    unless `which mysql_install_db 2>/dev/null` || `mysqld --verbose --help 2>/dev/null | grep '\\--initialize-insecure'`;
 use strict;
 use warnings;
 use Test::Requires qw/DBI/;

--- a/t/02_prepare.t
+++ b/t/02_prepare.t
@@ -13,6 +13,7 @@ my $out = run_test({
     tests    => [ 't/plx/prepare.plx' ],
     preparer => 't::Util',
 });
-exit_status_is( 0 );
+exit_status_is( 0 )
+    or diag "out = '$out'";
 
 done_testing;

--- a/t/03_includes.t
+++ b/t/03_includes.t
@@ -14,6 +14,7 @@ my $out = run_test({
     preparer => 'Util',
     includes => 't/lib',
 });
-exit_status_is( 0 );
+exit_status_is( 0 )
+    or diag "out = '$out'";
 
 done_testing;

--- a/t/03_includes.t
+++ b/t/03_includes.t
@@ -1,6 +1,6 @@
 use Test::More;
-plan skip_all => 'mysql_install_db not found'
-    unless `which mysql_install_db 2>/dev/null`;
+plan skip_all => 'mysql_install_db or mysqld --intiialize-insecure are not found'
+    unless `which mysql_install_db 2>/dev/null` || `mysqld --verbose --help 2>/dev/null | grep '\\--initialize-insecure'`;
 use strict;
 use warnings;
 use Test::Requires qw/DBI/;

--- a/t/04_fork_hooks.t
+++ b/t/04_fork_hooks.t
@@ -1,0 +1,23 @@
+use Test::More;
+plan skip_all => 'mysql_install_db or mysqld --intiialize-insecure are not found'
+    unless `which mysql_install_db 2>/dev/null` || `mysqld --verbose --help 2>/dev/null | grep '\\--initialize-insecure'`;
+use strict;
+use warnings;
+use Test::Requires qw/DBI App::ForkProve/;
+
+use FindBin;
+use lib "$FindBin::RealBin/../";
+use t::Util;
+
+my $out = run_test({
+    tests  => [ './t/plx/fork_hooks.plx' ],
+    runner => 'forkprove', # this problem is occurred on forkprove only
+});
+exit_status_is( 0 );
+
+my (@dsns) = ( $out =~ m!dsn:(.+)$!gm );
+
+is( (scalar @dsns), 2 );
+is( $dsns[ 0 ], $dsns[ 1 ], 'should not be re-assigned' );
+
+done_testing;

--- a/t/04_fork_hooks.t
+++ b/t/04_fork_hooks.t
@@ -13,11 +13,14 @@ my $out = run_test({
     tests  => [ './t/plx/fork_hooks.plx' ],
     runner => 'forkprove', # this problem is occurred on forkprove only
 });
-exit_status_is( 0 );
+exit_status_is( 0 )
+    or diag "out = '$out'";
 
 my (@dsns) = ( $out =~ m!dsn:(.+)$!gm );
 
-is( (scalar @dsns), 2 );
-is( $dsns[ 0 ], $dsns[ 1 ], 'should not be re-assigned' );
+is( (scalar @dsns), 2 )
+    or diag explain { dsns => \@dsns, out => $out };
+is( $dsns[ 0 ], $dsns[ 1 ], 'should not be re-assigned' )
+    or diag explain { dsns => \@dsns, out => $out };
 
 done_testing;

--- a/t/plx/fork_hooks.plx
+++ b/t/plx/fork_hooks.plx
@@ -1,0 +1,23 @@
+use Test::More;
+use strict;
+use warnings;
+
+pass("dsn:$ENV{PERL_TEST_MYSQLPOOL_DSN}");
+
+pipe my $reader, my $writer;
+
+my $pid = fork;
+die "failed to fork: $!" unless defined $pid;
+if ($pid == 0) {
+    close $reader;
+    print $writer "dsn:$ENV{PERL_TEST_MYSQLPOOL_DSN}";
+    close $writer;
+    exit;
+}
+close $writer;
+my $result = <$reader>;
+wait;
+
+pass($result);
+
+done_testing;


### PR DESCRIPTION
Before, even in the case of forking during test execution, the child process was allocated mysqld from the pool.
With this behavior, if a fork happens during a test, the allocated mysqld will be exhausted and the test will get stuck. (if jobs=1)

So this patch makes to restrict execution the forking hook only for the direct children.